### PR TITLE
fixed filenames and required packages in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pyproj
 scipy
 tqdm
 xarray
+cached-property
+attrdict

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 import os
 
 # Get the readme
-with open('README.rst') as f:
+with open('README.md') as f:
     readme = f.read()
 
 # Get the licence


### PR DESCRIPTION
These were modifications I needed to install the package with `python setup.py install`: Replaced old README.rst with the md-file in setup.py and added required packages for installation to requirements.txt
