### PR TITLE
fixed mix up of lat and lon attributes in export

### DIFF
--- a/awi_als_toolbox/_grid.py
+++ b/awi_als_toolbox/_grid.py
@@ -926,7 +926,7 @@ class ALSMergedGrid(object):
         data_vars["lon"] = xr.Variable(coord_dims, self.lons.astype(np.float32),
                                        attrs=self.cfg.get_var_attrs("lon"))
         data_vars["lat"] = xr.Variable(coord_dims, self.lats.astype(np.float32),
-                                       attrs=self.cfg.get_var_attrs("lon"))
+                                       attrs=self.cfg.get_var_attrs("lat"))
         #data_vars = {"elevation": xr.Variable(grid_dims, self.grid.astype(np.float32)),
         #             "lon": xr.Variable(coord_dims, self.lons.astype(np.float32)),
         #             "lat": xr.Variable(coord_dims, self.lats.astype(np.float32))}


### PR DESCRIPTION
Correct typo in the attributes of lat and lon in the netcdf export.

Solves issue #12 