### PR TITLE
Elevation correction and uncertainty computation

### DIFF
--- a/awi_als_toolbox/_grid.py
+++ b/awi_als_toolbox/_grid.py
@@ -1073,8 +1073,8 @@ class ALSMergedGrid(object):
         
         data_vars["lon"] = xr.Variable(grid_dims, self.lons.astype(np.float32),
                                        attrs=self.cfg.get_var_attrs("lon"))
-        data_vars["lat"] = xr.Variable(grid_dims, self.lats.astype(np.float32),
-                                       attrs=self.cfg.get_var_attrs("lon"))
+        data_vars["lat"] = xr.Variable(coord_dims, self.lats.astype(np.float32),
+                                       attrs=self.cfg.get_var_attrs("lat"))
 
         # Collect all coords
         coords = {"time": xr.Variable("time", [np.mean(self.reftimes)], attrs=self.cfg.get_var_attrs("time")),

--- a/awi_als_toolbox/export.py
+++ b/awi_als_toolbox/export.py
@@ -141,7 +141,7 @@ class AlsDEMNetCDF(object):
         """
         template = str(self.cfg.filenaming)
         filename = template.format(proc_level=self.dem.fn_proc_level, res=self.dem.fn_res,
-                        tcs=self.dem.fn_tcs, tce=self.dem.fn_tce)
+                                   tcs=self.dem.fn_tcs, tce=self.dem.fn_tce)
         return filename
 
     @property


### PR DESCRIPTION
Overlapping segments in floe grids are used to compute:
- a correction term for temporal varying elevation offset between segments
- uncertainty estimates for elevation in overlapping parts

A new atmospheric backscatter filter is added that filters all elevation data that are outside the [-threshold,threshold] interval around the first mode of the elevation data, which represents the sea ice and snow surface.